### PR TITLE
Fix: Corrected a few typos of rlcpy to rclpy.

### DIFF
--- a/karura_gui/src/dashboard/backend/base_node.py
+++ b/karura_gui/src/dashboard/backend/base_node.py
@@ -1,5 +1,5 @@
-import rlcpy
-from rlcpy import Node  
+import rclpy
+from rclpy import Node  
 
 class BaseDashboardNode(Node):
     """

--- a/karura_gui/src/dashboard/core/ros2_worker.py
+++ b/karura_gui/src/dashboard/core/ros2_worker.py
@@ -9,7 +9,7 @@ class ROS2Worker(QThread):
         
     def run(self):
         try:
-            while self._running and rlcpy.ok():
+            while self._running and rclpy.ok():
                 rclpy.spin_once(self.node, timeout_sec=0.1)
         except Exception as e:
             print(f"ROS2Worker encountered an error: {e}")


### PR DESCRIPTION
### Summary
This PR addresses a critical initialization bug by correcting the common typo `rlcpy` to `rclpy` in the core backend files.

### Changes Made:
1. **`base_node.py`**: Corrected `import rlcpy` to `import rclpy` (in two places) to ensure ROS 2 nodes can be initialized correctly.
2. **`ros2_worker.py`**: Corrected the check `rlcpy.ok()` to `rclpy.ok()` to ensure the ROS 2 background thread spins correctly.

### Impact
This is a high-priority bug fix required for **any** ROS 2 node (including the Mobility and Science nodes) to start spinning in the GUI environment.